### PR TITLE
Install vim commentary

### DIFF
--- a/environments/ubuntu-common/dev_env_tasks.yml
+++ b/environments/ubuntu-common/dev_env_tasks.yml
@@ -165,7 +165,7 @@
 
 - name: Execute :PlugInstall to install the configured vim-plug plugins
   shell:
-    cmd: vim -c PlugInstall
+    cmd: vim -c PlugInstall -c qall
 
 - name: Create or diff ~/.oh-my-zsh/custom/aliases.zsh
   import_tasks: "{{ environments_dir }}/ansible-common/copy_or_diff.yml"

--- a/environments/ubuntu-common/dev_env_tasks.yml
+++ b/environments/ubuntu-common/dev_env_tasks.yml
@@ -120,14 +120,6 @@
     readable_dest: ~/.zshrc
     mode: '0644'
 
-- name: Create or diff ~/.vimrc
-  import_tasks: "{{ environments_dir }}/ansible-common/copy_or_diff.yml"
-  vars:
-    src: "{{ environments_dir }}/ubuntu-common/vimrc"
-    dest: "{{ vimrc_filepath }}"
-    readable_dest: ~/.vimrc
-    mode: '0644'
-
 - name: Create or diff ~/.gitconfig
   import_tasks: "{{ environments_dir }}/ansible-common/copy_or_diff.yml"
   vars:
@@ -146,13 +138,34 @@
   file:
     path: "{{ home_dir }}/.vim/swap"
     state: directory
-    recurse: yes
 
 - name: Ensure that the ~/.vim/undo directory exists
   file:
     path: "{{ home_dir }}/.vim/undo"
     state: directory
-    recurse: yes
+
+- name: Ensure that the ~/.vim/autoload directory exists
+  file:
+    path: "{{ home_dir }}/.vim/autoload"
+    state: directory
+
+- name: Ensure vim-plug is downloaded
+  get_url:
+    url: https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+    dest: "{{ home_dir }}/.vim/autoload/plug.vim"
+    mode: 0644
+
+- name: Create or diff ~/.vimrc
+  import_tasks: "{{ environments_dir }}/ansible-common/copy_or_diff.yml"
+  vars:
+    src: "{{ environments_dir }}/ubuntu-common/vimrc"
+    dest: "{{ vimrc_filepath }}"
+    readable_dest: ~/.vimrc
+    mode: '0644'
+
+- name: Execute :PlugInstall to install the configured vim-plug plugins
+  shell:
+    cmd: vim -c PlugInstall
 
 - name: Create or diff ~/.oh-my-zsh/custom/aliases.zsh
   import_tasks: "{{ environments_dir }}/ansible-common/copy_or_diff.yml"

--- a/environments/ubuntu-common/vimrc
+++ b/environments/ubuntu-common/vimrc
@@ -93,3 +93,25 @@ if &term =~? 'rxvt' || &term =~? 'xterm' || &term =~? 'st-'
     let &t_EI .= "\<Esc>[2 q"
 endif
 
+" TASK [Enable the vim-plug plugins]
+
+call plug#begin('~/.vim/plugged')
+
+" TASK [Enable the vim-commentary plugin to provide the 'gc' command]
+
+Plug 'tpope/vim-commentary'
+
+" TASK [Retain some popular example plugins]
+"
+" The vim-sensible plugin aims to provide sensible vim defaults similar to
+" this file. However, we don't use it because a collaborator may not want vim
+" to automatically reload a buffer when its file changes on disk.
+"
+" The Fuzzy Finder plugin is super popular, but it isn't necessary for typical
+" system administration tasks.
+"
+" Plug 'tpope/vim-sensible'
+" Plug 'junegunn/fzf', { 'do': { -> fzf#setup() } }
+
+call plug#end()
+


### PR DESCRIPTION
The vim-commentary plugin enables commenting/uncommenting blocks using
the 'gc' command.

We use the vim-plug plugin manager because most of the vim maintainers
recommend it as opposed to the pathogen plugin manager.