### PR TITLE
Docker native vscode

### DIFF
--- a/environments/ubuntu-common/dev_env_tasks.yml
+++ b/environments/ubuntu-common/dev_env_tasks.yml
@@ -79,9 +79,13 @@
     state: present
   become: yes
 
-- name: Determine the jq binary
+- name: Determine the yq architecture
   set_fact:
-    yq_download_binary_name: "{{ 'yq_linux_amd64' if ansible_facts['architecture'] in [ 'x86_64', 'amd64' ] else 'yq_linux_arm64' }}"
+    yq_architecture: "{{ 'amd64' if ansible_facts['architecture'] == 'x86_64' else ansible_facts['architecture'] }}"
+
+- name: Determine the yq download binary name
+  set_fact:
+    yq_download_binary_name: "yq_{{ ansible_facts['os_family']|lower }}{{ yq_architecture }}"
 
 - name: Install yq
   # Note: We install this without using a package manager because we need the

--- a/environments/ubuntu_20.04-docker-native/Dockerfile
+++ b/environments/ubuntu_20.04-docker-native/Dockerfile
@@ -111,6 +111,7 @@ RUN mkdir /var/run/sshd
 # TASK [Install the VSCode Server]
 
 RUN export DEBIAN_FRONTEND=noninteractive \
+    && mkdir /etc/apt/keyrings \
     && wget -qO- https://packages.microsoft.com/keys/microsoft.asc \
       | gpg --dearmor > /etc/apt/keyrings/packages.microsoft.gpg \
     && echo "deb [arch=amd64,arm64,armhf signed-by=/etc/apt/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main" \

--- a/environments/ubuntu_20.04-docker-native/Dockerfile
+++ b/environments/ubuntu_20.04-docker-native/Dockerfile
@@ -32,6 +32,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
       ca-certificates \
       clang \
       cmake \
+      code \
       coreutils \
       cppcheck \
       curl \
@@ -70,6 +71,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
       net-tools \
       netcat \
       openssh-client \
+      openssh-server \
       procps \
       psmisc \
       python-pip-whl \
@@ -101,6 +103,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 RUN if ! grep -o -E '^\s*en_US.UTF-8\s+UTF-8' /etc/locale.gen > /dev/null; then \
       echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen; \
     fi
+
+# TASK [Configure sshd]
+
+RUN mkdir /var/run/sshd
 
 # TASK [Install ROS2 Desktop and its many dependencies]
 #
@@ -141,6 +147,10 @@ RUN groupadd --system --gid "${DOCKER_GID}" docker \
     && echo -n "${USERNAME}:${USERNAME}" | chpasswd
 
 COPY --chown="${USERNAME}:${USERNAME}" --chmod=644 [ "build/gitconfig", "/home/${USERNAME}/.gitconfig" ]
+
+# TASK [Enable the default user to start sshd]
+
+RUN echo "${USERNAME} ALL=(ALL:ALL) NOPASSWD: /usr/sbin/sshd -D" > /etc/sudoers.d/sshd_sudoers
 
 # TASK [Become the default user]
 

--- a/environments/ubuntu_20.04-docker-native/Dockerfile
+++ b/environments/ubuntu_20.04-docker-native/Dockerfile
@@ -32,7 +32,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
       ca-certificates \
       clang \
       cmake \
-      code \
       coreutils \
       cppcheck \
       curl \
@@ -42,6 +41,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
       gdb \
       git \
       gnupg2 \
+      gpg \
       grep \
       htop \
       info \
@@ -107,6 +107,16 @@ RUN if ! grep -o -E '^\s*en_US.UTF-8\s+UTF-8' /etc/locale.gen > /dev/null; then 
 # TASK [Configure sshd]
 
 RUN mkdir /var/run/sshd
+
+# TASK [Install the VSCode Server]
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && wget -qO- https://packages.microsoft.com/keys/microsoft.asc \
+      | gpg --dearmor > /etc/apt/keyrings/packages.microsoft.gpg \
+    && echo "deb [arch=amd64,arm64,armhf signed-by=/etc/apt/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main" \
+      | tee /etc/apt/sources.list.d/vscode.list > /dev/null \
+    && apt-get update \
+    && apt-get install -yq --no-install-recommends code
 
 # TASK [Install ROS2 Desktop and its many dependencies]
 #

--- a/environments/ubuntu_20.04-docker-native/Dockerfile
+++ b/environments/ubuntu_20.04-docker-native/Dockerfile
@@ -108,6 +108,8 @@ RUN if ! grep -o -E '^\s*en_US.UTF-8\s+UTF-8' /etc/locale.gen > /dev/null; then 
 
 RUN mkdir /var/run/sshd
 
+EXPOSE 22
+
 # TASK [Install the VSCode Server]
 
 RUN export DEBIAN_FRONTEND=noninteractive \

--- a/environments/ubuntu_20.04-docker-native/Dockerfile
+++ b/environments/ubuntu_20.04-docker-native/Dockerfile
@@ -156,10 +156,20 @@ ARG USERNAME='devops'
 
 RUN groupadd --system --gid "${DOCKER_GID}" docker \
     && groupadd --gid "${USER_GID}" "${USERNAME}" \
-    && useradd --create-home --shell '/bin/bash' --uid "${USER_UID}" --gid "${USERNAME}" --groups 'sudo,docker' "${USERNAME}" \
-    && echo -n "${USERNAME}:${USERNAME}" | chpasswd
+    && useradd --create-home --shell '/bin/bash' --uid "${USER_UID}" \
+      --gid "${USERNAME}" --groups 'sudo,docker' "${USERNAME}" \
+    && echo -n "${USERNAME}:${USERNAME}" | chpasswd \
+    && install -o "${USERNAME}" -g "${USERNAME}" -m 700 -d "/home/${USERNAME}/.ssh"
 
-COPY --chown="${USERNAME}:${USERNAME}" --chmod=644 [ "build/gitconfig", "/home/${USERNAME}/.gitconfig" ]
+# TASK [Provision the host environment gitconfig that was provided by setup.sh]
+
+COPY --chown="${USERNAME}:${USERNAME}" --chmod=644 [ "build/gitconfig", \
+    "/home/${USERNAME}/.gitconfig" ]
+
+# TASK [Provision the ssh authorized_keys that was provided by setup.sh]
+
+copy --chown="${USERNAME}:${USERNAME}" --chmod=600 [ "build/ssh_authorized_keys", \
+    "/home/${USERNAME}/.ssh/authorized_keys" ]
 
 # TASK [Enable the default user to start sshd]
 

--- a/environments/ubuntu_20.04-docker-native/entrypoint.sh
+++ b/environments/ubuntu_20.04-docker-native/entrypoint.sh
@@ -7,6 +7,12 @@ rc=0
 
 INIT_FLAG_FILEPATH="${HOME}/.user-dir-initialized"
 
+# TASK [Start sshd]
+
+sudo /usr/sbin/sshd -D
+
+# TASK [Determine whether the user's nome directory needs to be initialized]
+
 if [[ ! -f "${INIT_FLAG_FILEPATH}" ]]; then
 
   # TASK [Initializes the user's home directory in the /home volume`]

--- a/environments/ubuntu_20.04-docker-native/setup.sh
+++ b/environments/ubuntu_20.04-docker-native/setup.sh
@@ -95,6 +95,7 @@ BUILD_NO_CACHE_OPTION="${BUILD_NO_CACHE_OPTION:-}"
 REPO_CACHE_ID="${REPO_CACHE_ID:-0}"
 DEV_ENV_USERNAME='devops' # This is also the default password for the user.
 SSH_PRIVATE_KEY_FILEPATH="${HOME}/.ssh/${SSH_KEYPAIR_NAME}"
+SSH_PUBLIC_KEY_FILEPATH="${HOME}/.ssh/${SSH_KEYPAIR_NAME}.pub"
 BUILD_CONTEXT_DIR="${ENVIRONMENTS_DIR}/ubuntu_20.04-docker-native"
 IMAGE_NAME='jugglebot-native-dev:focal'
 CONTAINER_NAME='jugglebot-native-dev'
@@ -114,6 +115,10 @@ task 'Copy ~/.gitconfig into the build context'
 
 install -D -T "${HOME}/.gitconfig" "${BUILD_CONTEXT_DIR}/build/gitconfig"
 
+task "Copy ~/.ssh/${SSH_KEYPAIR_NAME}.pub into the build context"
+
+install -D -T "${SSH_PUBLIC_KEY_FILEPATH}" "${BUILD_CONTEXT_DIR}/build/ssh_authorized_keys"
+
 task "Build the docker image named ${IMAGE_NAME}"
 
 docker buildx build ${BUILD_NO_CACHE_OPTION} \
@@ -130,7 +135,8 @@ docker buildx build ${BUILD_NO_CACHE_OPTION} \
 
 task 'Cleanup the build context'
 
-rm "${BUILD_CONTEXT_DIR}/build/gitconfig"
+rm -f "${BUILD_CONTEXT_DIR}/build/gitconfig"
+rm -f "${BUILD_CONTEXT_DIR}/build/ssh_authorized_keys"
 
 task "Ensure that the docker volume named ${HOME_VOLUME_NAME} exists"
 
@@ -162,7 +168,7 @@ docker container create --name "${CONTAINER_NAME}" \
   -v '/var/run/docker.sock:/var/run/docker.sock' \
   -v "${HOME_VOLUME_NAME}:/home" \
   -v "${HOME}/.oh-my-zsh/custom:/entrypoint/oh-my-zsh-custom" \
-  -p '2222:22' \
+  -p '4422:22' \
   --dns '8.8.8.8' \
   "${IMAGE_NAME}"
 

--- a/environments/ubuntu_20.04-docker-native/setup.sh
+++ b/environments/ubuntu_20.04-docker-native/setup.sh
@@ -162,6 +162,7 @@ docker container create --name "${CONTAINER_NAME}" \
   -v '/var/run/docker.sock:/var/run/docker.sock' \
   -v "${HOME_VOLUME_NAME}:/home" \
   -v "${HOME}/.oh-my-zsh/custom:/entrypoint/oh-my-zsh-custom" \
+  -p '2222:22' \
   --dns '8.8.8.8' \
   "${IMAGE_NAME}"
 

--- a/environments/ubuntu_24.04-wsl2/main_playbook.yml
+++ b/environments/ubuntu_24.04-wsl2/main_playbook.yml
@@ -71,13 +71,25 @@
   - name: Add an ssh config for GitHub
     community.general.ssh_config:
       user: "{{ username }}"
-      host: 'github.com'
-      hostname: 'github.com'
-      remote_user: 'git'
+      host: github.com
+      hostname: github.com
+      remote_user: git
       identity_file: "~/.ssh/{{ ssh_keypair_name }}"
       identities_only: yes
       add_keys_to_agent: yes
       strict_host_key_checking: accept-new
+
+  - name: Add an ssh config for docker-native-env
+    community.general.ssh_config:
+      user: "{{ username }}"
+      host: docker-native-env
+      hostname: localhost
+      remote_user: devops
+      port: 4422
+      identity_file: "~/.ssh/{{ ssh_keypair_name }}"
+      identities_only: yes
+      add_keys_to_agent: yes
+      strict_host_key_checking: no
 
   - name: Set user name in ~/.gitconfig
     community.general.ini_file:


### PR DESCRIPTION
1. Add the VSCode Server to the container
2. Run an ssh server in the container
3. Add the ssh public key to the authorized_keys for the devops user in the container
4. Expose the ssh port 22 of the container as port 4422 on localhost
