### PR TITLE
Init ROS workspace

### DIFF
--- a/environments/README.md
+++ b/environments/README.md
@@ -14,8 +14,9 @@ environment runs the version of ROS2 that has tier 1 support for that Ubuntu
 release. If you want to run the same version of ROS2 as Prod runs, you should 
 install Ubuntu-20.04 for WSL despite that Ubuntu release being relatively old.
 
-You can attach VSCode for Windows to the WSL2 environment by running
-the following command from within the WSL2 environment:
+After following Steps 1 through 8 of the Instructions below, you can attach
+VSCode for Windows to the WSL2 environment by running the following command from
+within the WSL2 environment:
 
 ```zsh
 cd ~/Jugglebot && code .
@@ -234,7 +235,7 @@ wsl -d Ubuntu-20.04
 Within the WSL2 environment, run the setup script for the docker native platform
 environment. This will take some time.
 
-```bash
+```zsh
 ~/Jugglebot/environments/ubuntu_20.04-docker-native/setup.sh --ssh-keypair-name id_ed25519 --debug-git-branch dev-env-provisioning
 ```
 
@@ -244,8 +245,8 @@ The script in Step 9 will print some information about the container that it
 builds. After reading that info, run the following command to enter the docker
 native platform environment.
 
-```bash
-docker-native-env
+```zsh
+exec-native-docker-dev
 ```
 
 ## Notes

--- a/environments/ubuntu-common/dev_env_tasks.yml
+++ b/environments/ubuntu-common/dev_env_tasks.yml
@@ -69,7 +69,7 @@
     dest: "{{ packages_upgraded_filepath }}"
   when: upgrade_software|bool and upgrade_packages_result is succeeded
 
-- name: Ensure that git, jq, keychain and zsh are installed
+- name: Ensure that git, jq, keychain, tmux and zsh are installed
   package:
     name:
     - git

--- a/environments/ubuntu-common/dev_env_tasks.yml
+++ b/environments/ubuntu-common/dev_env_tasks.yml
@@ -205,8 +205,9 @@
 
 - name: Disable the sudo welcome message
   file:
-    path: "{{ home_dir }}/.sudo_as_admin_successful"
+    path: "{{ sudo_welcome_flag_filepath }}"
     state: touch
+  when: not sudo_welcome_flag_filepath is file
   
 - name: Create or diff ~/.tmux.conf
   import_tasks: "{{ environments_dir }}/ansible-common/copy_or_diff.yml"

--- a/environments/ubuntu-common/dev_env_vars.yml
+++ b/environments/ubuntu-common/dev_env_vars.yml
@@ -3,6 +3,7 @@ upgrade_software: "{{ upgrade_software if upgrade_software else no }}"
 ssh_keypair_name: ''
 home_dir: "{{ ansible_facts['env']['HOME'] }}"
 username: "{{ ansible_facts['env']['USER'] }}"
+sudo_welcome_flag_filepath: "{{ home_dir }}.sudo_as_admin_successful"
 jugglebot_config_dir: "{{ home_dir }}/.jugglebot"
 host_setup_dir: "{{ home_dir }}/.jugglebot/host_setup"
 host_setup_backups_dir: "{{ home_dir }}/.jugglebot/host_setup/backups"

--- a/environments/ubuntu-common/dev_env_vars.yml
+++ b/environments/ubuntu-common/dev_env_vars.yml
@@ -3,7 +3,7 @@ upgrade_software: "{{ upgrade_software if upgrade_software else no }}"
 ssh_keypair_name: ''
 home_dir: "{{ ansible_facts['env']['HOME'] }}"
 username: "{{ ansible_facts['env']['USER'] }}"
-sudo_welcome_flag_filepath: "{{ home_dir }}.sudo_as_admin_successful"
+sudo_welcome_flag_filepath: "{{ home_dir }}/.sudo_as_admin_successful"
 jugglebot_config_dir: "{{ home_dir }}/.jugglebot"
 host_setup_dir: "{{ home_dir }}/.jugglebot/host_setup"
 host_setup_backups_dir: "{{ home_dir }}/.jugglebot/host_setup/backups"

--- a/environments/ubuntu-common/docker_engine_tasks.yml
+++ b/environments/ubuntu-common/docker_engine_tasks.yml
@@ -17,14 +17,14 @@
     state: present
   become: yes
 
-- name: Ensure that the docker daemon is enabled and started
+- name: Ensure that the Docker Engine daemon is enabled and started
   systemd_service:
     name: docker
     enabled: yes
     state: started
   become: yes
 
-- name: Create the docker group to manage access to the docker engine
+- name: Create the docker group to manage access to the Docker Engine
   group:
     name: docker
     state: present

--- a/environments/ubuntu-wsl2/exec-native-docker-dev
+++ b/environments/ubuntu-wsl2/exec-native-docker-dev
@@ -3,7 +3,9 @@ set -o nounset -o pipefail -o errexit
 IFS=$'\t\n' # Stricter IFS settings
 rc=0
 
-~/bin/start-native-docker-dev
+CONTAINER_NAME='jugglebot-native-dev'
+
+~/bin/start-native-docker-dev --container-name "${CONTAINER_NAME}"
 
 # TASK [Run an interactive shell in the container]
 #

--- a/environments/ubuntu-wsl2/exec-native-docker-dev
+++ b/environments/ubuntu-wsl2/exec-native-docker-dev
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -o nounset -o pipefail -o errexit
+IFS=$'\t\n' # Stricter IFS settings
+rc=0
+
+~/bin/start-native-docker-dev
+
+# TASK [Run an interactive shell in the container]
+#
+# Note: The SSH_AUTH_SOCK is typically located beneath /tmp, and the container
+# already has /tmp mounted.
+
+docker exec -it \
+  -e "SSH_AUTH_SOCK='${SSH_AUTH_SOCK:-}'" \
+  "${CONTAINER_NAME}" \
+  '/usr/bin/zsh'
+
+

--- a/environments/ubuntu-wsl2/exec-native-docker-dev
+++ b/environments/ubuntu-wsl2/exec-native-docker-dev
@@ -17,4 +17,3 @@ docker exec -it \
   "${CONTAINER_NAME}" \
   '/usr/bin/zsh'
 
-

--- a/environments/ubuntu-wsl2/main_playbook.yml
+++ b/environments/ubuntu-wsl2/main_playbook.yml
@@ -53,8 +53,9 @@
 
   - name: Disable the WSL welcome message
     file:
-      path: "{{ home_dir }}/.hushlogin"
+      path: "{{ wsl_welcome_flag_filepath }}"
       state: touch
+    when: not wsl_welcome_flag_filepath is file
 
   - name: Provision the Ubuntu environment
     import_tasks: "{{ environments_dir }}/ubuntu-common/dev_env_tasks.yml"

--- a/environments/ubuntu-wsl2/main_playbook.yml
+++ b/environments/ubuntu-wsl2/main_playbook.yml
@@ -167,8 +167,12 @@
     command:
       cmd: /usr/bin/rosdep update
 
+  - name: Determine the current shell
+    set_fact:
+      shell: "{{ ansible_facts['env']['SHELL']|basename }}"
+
   - name: Install the Jugglebot ROS dependencies
-    command:
-      cmd: "/usr/bin/rosdep install -i --from-path src --rosdistro {{ ros_version_codename }}"
+    shell:
+      cmd: "source /opt/ros/{{ ros_version_codename }}/setup.{{ shell }} && rosdep install -i --from-path src --rosdistro {{ ros_version_codename }}"
       chdir: "{{ home_dir }}/Jugglebot/ros_ws"
 

--- a/environments/ubuntu-wsl2/main_playbook.yml
+++ b/environments/ubuntu-wsl2/main_playbook.yml
@@ -163,6 +163,10 @@
     when: not '/etc/ros/rosdep/sources.list.d/20-default.list' is file
     become: yes
 
+  - name: Update the rosdep package manager
+    command:
+      cmd: /usr/bin/rosdep update
+
   - name: Install the Jugglebot ROS dependencies
     command:
       cmd: "/usr/bin/rosdep install -i --from-path src --rosdistro {{ ros_version_codename }}"

--- a/environments/ubuntu-wsl2/main_playbook.yml
+++ b/environments/ubuntu-wsl2/main_playbook.yml
@@ -123,12 +123,12 @@
       readable_dest: ~/bin/docker-native-env
       mode: '0755'
 
-  - name: Read the ROS2 codename
+  - name: Read the ROS codename
     command:
       cmd: "/usr/bin/yq -r .ros.version_codename '{{ jugglebot_rc_rendered_filepath }}'"
     register: yq_command_result
 
-  - name: Set the ROS2 codename
+  - name: Set the ROS codename variable
     set_fact:
       ros_version_codename: "{{ yq_command_result.stdout }}"
 
@@ -140,13 +140,31 @@
     when: ros_version_codename == 'foxy'
 
   - name: "Install ROS2 {{ ros_version_codename|capitalize }} Desktop .. please be patient"
-    # Note: We install version of ROS2 that has tier 1 support for this LTS
-    # version. See the ~/ubuntu-common/jugglebot_rc.yml.j2 for the mapping of
-    # LTS version to ROS2 codename.
+    #
+    # Note 1: We install version of ROS2 that has tier 1 support for this
+    # Ubuntu LTS release. See the ~/ubuntu-common/jugglebot_rc.yml.j2 for the
+    # mapping of LTS release to ROS2 codename.
+    #
+    # Note 2: We also install the webots package because it supplies the
+    # webots_ros2_driver that is required by the following package:
+    # Jugglebot/ros_ws/src/jugglebot_simulator/package.xml
+    #
     package:
       name: 
         - "ros-{{ ros_version_codename }}-desktop"
+        - "ros-{{ ros_version_codename }}-webots-ros2"
         - ros-dev-tools
       state: present
     become: yes
+
+  - name: Initialize the rosdep package manager
+    command:
+      cmd: /usr/bin/rosdep init
+    when: not '/etc/ros/rosdep/sources.list.d/20-default.list' is file
+    become: yes
+
+  - name: Install the Jugglebot ROS dependencies
+    command:
+      cmd: "/usr/bin/rosdep install -i --from-path src --rosdistro {{ ros_version_codename }}"
+      chdir: "{{ home_dir }}/Jugglebot/ros_ws"
 

--- a/environments/ubuntu-wsl2/main_playbook.yml
+++ b/environments/ubuntu-wsl2/main_playbook.yml
@@ -127,6 +127,7 @@
     command:
       cmd: "/usr/bin/yq -r .ros.version_codename '{{ jugglebot_rc_rendered_filepath }}'"
     register: yq_command_result
+    changed_when: False
 
   - name: Set the ROS codename variable
     set_fact:

--- a/environments/ubuntu-wsl2/main_playbook.yml
+++ b/environments/ubuntu-wsl2/main_playbook.yml
@@ -167,12 +167,9 @@
     command:
       cmd: /usr/bin/rosdep update
 
-  - name: Determine the current shell
-    set_fact:
-      shell: "{{ ansible_facts['env']['SHELL']|basename }}"
-
   - name: Install the Jugglebot ROS dependencies
     shell:
-      cmd: "source /opt/ros/{{ ros_version_codename }}/setup.{{ shell }} && rosdep install -i --from-path src --rosdistro {{ ros_version_codename }}"
+      cmd: "source /opt/ros/{{ ros_version_codename }}/setup.bash && rosdep install -i --from-path src --rosdistro {{ ros_version_codename }}"
+      executable: /usr/bin/bash
       chdir: "{{ home_dir }}/Jugglebot/ros_ws"
 

--- a/environments/ubuntu-wsl2/main_playbook.yml
+++ b/environments/ubuntu-wsl2/main_playbook.yml
@@ -117,12 +117,21 @@
   - name: Create or diff the docker-native-env script
     import_tasks: "{{ environments_dir }}/ansible-common/copy_or_diff.yml"
     vars:
-      src: "{{ environments_dir }}/ubuntu-wsl2/docker-native-env"
+      src: "{{ environments_dir }}/ubuntu-wsl2/start-native-docker-dev"
       remote_src: no
-      dest: "{{ home_dir }}/bin/docker-native-env"
-      readable_dest: ~/bin/docker-native-env
+      dest: "{{ home_dir }}/bin/start-native-docker-dev"
+      readable_dest: ~/bin/start-native-docker-dev
       mode: '0755'
 
+  - name: Create or diff the docker-native-env script
+    import_tasks: "{{ environments_dir }}/ansible-common/copy_or_diff.yml"
+    vars:
+      src: "{{ environments_dir }}/ubuntu-wsl2/exec-native-docker-dev"
+      remote_src: no
+      dest: "{{ home_dir }}/bin/exec-native-docker-dev"
+      readable_dest: ~/bin/start-native-docker-dev
+      mode: '0755'
+  
   - name: Read the ROS codename
     command:
       cmd: "/usr/bin/yq -r .ros.version_codename '{{ jugglebot_rc_rendered_filepath }}'"

--- a/environments/ubuntu-wsl2/main_vars.yml
+++ b/environments/ubuntu-wsl2/main_vars.yml
@@ -1,6 +1,7 @@
 ---
 
 home_dir: "{{ ansible_facts['env']['HOME'] }}"
+wsl_welcome_flag_filepath: "{{ home_dir }}/.hushlogin"
 ssh_config_rendered_filepath: "{{ home_dir }}/.jugglebot/host_setup/defaults/ssh_config"
 jugglebot_rc_rendered_filepath: "{{ home_dir }}/.jugglebot/host_setup/defaults/jugglebot_rc.yml"
 ssh_private_key_filepath: "{{ home_dir }}/.ssh/{{ ssh_keypair_name }}"

--- a/environments/ubuntu-wsl2/start-native-docker-dev
+++ b/environments/ubuntu-wsl2/start-native-docker-dev
@@ -3,9 +3,29 @@ set -o nounset -o pipefail -o errexit
 IFS=$'\t\n' # Stricter IFS settings
 rc=0
 
+# TASK [Parse the arguments]
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -c|--container-name)
+      CONTAINER_NAME="$2"
+      shift
+      shift
+      ;;
+    -*|--*)
+      echo "[ERROR]: Unknown option $1"
+      exit 1
+      ;;
+    *)
+      POSITIONAL_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
 # TASK [Initialize variables]
 
-CONTAINER_NAME='jugglebot-native-dev'
+CONTAINER_NAME="${CONTAINER_NAME:-jugglebot-native-dev}"
 EX_UNAVAILABLE=69
 
 # TASK [Define functions]

--- a/environments/ubuntu-wsl2/start-native-docker-dev
+++ b/environments/ubuntu-wsl2/start-native-docker-dev
@@ -10,14 +10,14 @@ EX_UNAVAILABLE=69
 
 # TASK [Define functions]
 
-is_docker_container_running() {
-  local container_name="$1"
-  [[ "$(docker container ls --quiet --filter "name=${container_name}")" != '' ]]
-}
-
 does_docker_container_exist() {
   local container_name="$1"
   [[ "$(docker container ls --quiet --all --filter "name=${container_name}")" != '' ]]
+}
+
+is_docker_container_running() {
+  local container_name="$1"
+  [[ "$(docker container ls --quiet --filter "name=${container_name}")" != '' ]]
 }
 
 is_home_dir_initialized() {
@@ -48,14 +48,4 @@ while ! is_home_dir_initialized "${CONTAINER_NAME}"; do
   echo "Waiting for the home directory in container ${CONTAINER_NAME} to be initialized..."
   sleep 2
 done
-
-# TASK [Run an interactive shell in the container]
-#
-# Note: The SSH_AUTH_SOCK is typically located beneath /tmp, and the container
-# already has /tmp mounted.
-
-docker exec -it \
-  -e "SSH_AUTH_SOCK='${SSH_AUTH_SOCK:-}'" \
-  "${CONTAINER_NAME}" \
-  '/usr/bin/zsh'
 

--- a/environments/ubuntu_20.04-docker-native/Dockerfile
+++ b/environments/ubuntu_20.04-docker-native/Dockerfile
@@ -137,7 +137,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get install -yq --no-install-recommends \
       python3-argcomplete \
       ros-dev-tools \
-      ros-foxy-desktop
+      ros-foxy-desktop \
+      ros-foxy-webots-ros2 \
+    && /usr/bin/rosdep init
 
 # TASK [Specify /home and /tmp as volumes]
 
@@ -211,12 +213,14 @@ WORKDIR "/home/${USERNAME}"
 # TASK [Initialize the base setup and playbook variable]
 
 ARG ENVIRONMENTS_DIR="/home/${USERNAME}/Jugglebot/environments"
+ARG JUGGLEBOT_ROS_WORKSPACE_DIR="/home/${USERNAME}/Jugglebot/ros_ws"
 
 # TASK [Run the ubuntu-common base setup and then the playbook]
 
 RUN "${ENVIRONMENTS_DIR}/ubuntu_20.04-docker-native/base_setup_and_playbook.sh" \
       --environments-dir "${ENVIRONMENTS_DIR}" \
       --jugglebot-conda-env-filepath "${ENVIRONMENTS_DIR}/ubuntu-common/jugglebot_conda_env.yml" \
+      --jugglebot-ros-workspace-dir "${JUGGLEBOT_ROS_WORKSPACE_DIR}" \
       --ansible-become-pass "${USERNAME}"
 
 # TASK [Install entrypoint.sh]

--- a/environments/ubuntu_20.04-docker-native/Dockerfile
+++ b/environments/ubuntu_20.04-docker-native/Dockerfile
@@ -213,14 +213,14 @@ WORKDIR "/home/${USERNAME}"
 # TASK [Initialize the base setup and playbook variable]
 
 ARG ENVIRONMENTS_DIR="/home/${USERNAME}/Jugglebot/environments"
-ARG JUGGLEBOT_ROS_WORKSPACE_DIR="/home/${USERNAME}/Jugglebot/ros_ws"
+ARG ROS_WORKSPACE_DIR="/home/${USERNAME}/Jugglebot/ros_ws"
 
 # TASK [Run the ubuntu-common base setup and then the playbook]
 
 RUN "${ENVIRONMENTS_DIR}/ubuntu_20.04-docker-native/base_setup_and_playbook.sh" \
       --environments-dir "${ENVIRONMENTS_DIR}" \
       --jugglebot-conda-env-filepath "${ENVIRONMENTS_DIR}/ubuntu-common/jugglebot_conda_env.yml" \
-      --jugglebot-ros-workspace-dir "${JUGGLEBOT_ROS_WORKSPACE_DIR}" \
+      --ros-workspace-dir "${ROS_WORKSPACE_DIR}" \
       --ansible-become-pass "${USERNAME}"
 
 # TASK [Install entrypoint.sh]

--- a/environments/ubuntu_20.04-docker-native/Dockerfile
+++ b/environments/ubuntu_20.04-docker-native/Dockerfile
@@ -206,7 +206,8 @@ ARG JUGGLEBOT_REPO_BRANCH='main'
 WORKDIR "/home/${USERNAME}/Jugglebot"
 
 RUN --mount=type=ssh,mode=0666 git pull \
-    && git checkout "${JUGGLEBOT_REPO_BRANCH}"
+    && git checkout "${JUGGLEBOT_REPO_BRANCH}" \
+    && git pull
 
 WORKDIR "/home/${USERNAME}"
 

--- a/environments/ubuntu_20.04-docker-native/base_setup_and_playbook.sh
+++ b/environments/ubuntu_20.04-docker-native/base_setup_and_playbook.sh
@@ -19,6 +19,11 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
+    -w|--ros-workspace-dir)
+      ROS_WORKSPACE_DIR="$2"
+      shift
+      shift
+      ;;
     -c|--jugglebot-conda-env-filepath)
       JUGGLEBOT_CONDA_ENV_FILEPATH="$2"
       shift
@@ -47,6 +52,13 @@ if [[ -z "${ENVIRONMENTS_DIR:-}" ]]; then
   exit 2
 fi
 
+task 'Assert that the ROS workspace directory was specified'
+
+if [[ -z "${ROS_WORKSPACE_DIR:-}" ]]; then
+  echo '[ERROR]: The ROS workspace directory is required. Invoke this command with the `--ros-workspace-dir "[directory path]"` option.'
+  exit 2
+fi
+
 task 'Assert that a conda environment config file was specified'
 
 if [[ -z "${JUGGLEBOT_CONDA_ENV_FILEPATH:-}" ]]; then
@@ -72,6 +84,7 @@ task 'Run the playbook'
 ANSIBLE_LOCALHOST_WARNING=False \
   ANSIBLE_INVENTORY_UNPARSED_WARNING=False \
   ANSIBLE_BECOME_PASS="${ANSIBLE_BECOME_PASS}" \
-  ansible-playbook "$ENVIRONMENTS_DIR/ubuntu_20.04-docker-native/main_playbook.yml" \
-    -e upgrade_software=yes
+  ansible-playbook "${ENVIRONMENTS_DIR}/ubuntu_20.04-docker-native/main_playbook.yml" \
+    -e upgrade_software=yes \
+    -e "ros_workspace_dir=${ROS_WORKSPACE_DIR}"
 

--- a/environments/ubuntu_20.04-docker-native/main_playbook.yml
+++ b/environments/ubuntu_20.04-docker-native/main_playbook.yml
@@ -4,7 +4,9 @@
   connection: local
   vars:
     environments_dir: "{{ playbook_dir }}/.."
-    ros_workspace_dir: "{{ ansible_facts['env']['HOME'] }}/Jugglebot/ros_ws"
+    home_dir: "{{ ansible_facts['env']['HOME'] }}"
+    ros_workspace_dir: "{{ home_dir }}/Jugglebot/ros_ws"
+    jugglebot_rc_rendered_filepath: "{{ home_dir }}/.jugglebot/host_setup/defaults/jugglebot_rc.yml"
 
   tasks:
 
@@ -12,7 +14,7 @@
     copy:
       remote_src: yes
       src: /etc/skel/
-      dest: "{{ ansible_facts['env']['HOME'] }}"
+      dest: "{{ home_dir }}"
       force: no
 
   - name: Require that the jugglebot Conda environment is activated
@@ -31,6 +33,15 @@
       name: docker-ce-cli
       state: present
     become: yes
+
+  - name: Read the ROS codename
+    command:
+      cmd: "/usr/bin/yq -r .ros.version_codename '{{ jugglebot_rc_rendered_filepath }}'"
+    register: yq_command_result
+
+  - name: Set the ROS codename variable
+    set_fact:
+      ros_version_codename: "{{ yq_command_result.stdout }}"
 
   - name: Install the Jugglebot ROS dependencies
     command:

--- a/environments/ubuntu_20.04-docker-native/main_playbook.yml
+++ b/environments/ubuntu_20.04-docker-native/main_playbook.yml
@@ -34,6 +34,10 @@
       state: present
     become: yes
 
+  - name: Update the rosdep package manager
+    command:
+      cmd: /usr/bin/rosdep update
+
   - name: Read the ROS codename
     command:
       cmd: "/usr/bin/yq -r .ros.version_codename '{{ jugglebot_rc_rendered_filepath }}'"

--- a/environments/ubuntu_20.04-docker-native/main_playbook.yml
+++ b/environments/ubuntu_20.04-docker-native/main_playbook.yml
@@ -42,6 +42,7 @@
     command:
       cmd: "/usr/bin/yq -r .ros.version_codename '{{ jugglebot_rc_rendered_filepath }}'"
     register: yq_command_result
+    changed_when: False
 
   - name: Set the ROS codename variable
     set_fact:

--- a/environments/ubuntu_20.04-docker-native/main_playbook.yml
+++ b/environments/ubuntu_20.04-docker-native/main_playbook.yml
@@ -48,7 +48,8 @@
       ros_version_codename: "{{ yq_command_result.stdout }}"
 
   - name: Install the Jugglebot ROS dependencies
-    command:
-      cmd: "/usr/bin/rosdep install -i --from-path src --rosdistro {{ ros_version_codename }}"
+    shell:
+      cmd: "source /opt/ros/{{ ros_version_codename }}/setup.bash && rosdep install -i --from-path src --rosdistro {{ ros_version_codename }}"
+      executable: /usr/bin/bash
       chdir: "{{ ros_workspace_dir }}"
  

--- a/environments/ubuntu_20.04-docker-native/main_playbook.yml
+++ b/environments/ubuntu_20.04-docker-native/main_playbook.yml
@@ -4,6 +4,7 @@
   connection: local
   vars:
     environments_dir: "{{ playbook_dir }}/.."
+    ros_workspace_dir: "{{ ansible_facts['env']['HOME'] }}/Jugglebot/ros_ws"
 
   tasks:
 
@@ -31,3 +32,8 @@
       state: present
     become: yes
 
+  - name: Install the Jugglebot ROS dependencies
+    command:
+      cmd: "/usr/bin/rosdep install -i --from-path src --rosdistro {{ ros_version_codename }}"
+      chdir: "{{ ros_workspace_dir }}"
+ 

--- a/environments/ubuntu_20.04-docker-native/setup.sh
+++ b/environments/ubuntu_20.04-docker-native/setup.sh
@@ -185,7 +185,7 @@ while ! is_home_dir_initialized "${CONTAINER_NAME}"; do
   sleep 2
 done
 
-echo ' DONE'
+echo ' done'
 
 task 'Stop the container'
 

--- a/environments/ubuntu_20.04-docker-native/setup.sh
+++ b/environments/ubuntu_20.04-docker-native/setup.sh
@@ -197,7 +197,7 @@ echo -e "
 Run the following command to open a shell in the jugglebot-native-dev
 container:
 
-docker-native-env
+exec-native-docker-dev
 
 ---
 


### PR DESCRIPTION
This installs all of the dependencies of the Jugglebot ROS workspace.

Along the way, we also got rid of some spurious changed statuses in the wsl playbook and separated the functions of the `docker-native-env` script into two scripts named `exec-native-docker-dev` and `start-native-docker-dev`. The `start-native-docker-dev` can be used to start the container in the background if you intend to ssh to it from VSCode for Windows.
