### PR TITLE
Fix dbus-launch and fix home directory initialization

### DIFF
--- a/environments/ubuntu-common/base_setup.sh
+++ b/environments/ubuntu-common/base_setup.sh
@@ -27,6 +27,8 @@ fi
 
 task 'Initialize variables'
 
+REFRESH_HOST_PROVISIONING_ENV_ENABLED="${REFRESH_HOST_PROVISIONING_ENV_ENABLED:-yes}"
+REFRESH_JUGGLEBOT_ENV_ENABLED="${REFRESH_JUGGLEBOT_ENV_ENABLED:-yes}"
 CONDA_SETUP_SCRIPT_URL="https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$( uname )-$( uname -m ).sh"
 HOST_SETUP_DIR="${HOME}/.jugglebot/host_setup"
 CONDA_SETUP_SCRIPT_FILEPATH="${HOME}/.jugglebot/host_setup/miniforge_setup.sh"
@@ -67,7 +69,10 @@ if [[ ! -f "${CONDA_FILEPATH}" ]]; then
   exit 3
 fi
 
-"${REPO_DIR}/environments/ubuntu-common/refresh-conda-env"
+"${REPO_DIR}/environments/ubuntu-common/refresh-conda-env" \
+  --refresh-host-provisioning-conda-env "${REFRESH_HOST_PROVISIONING_ENV_ENABLED}" \
+  --refresh-jugglebot-conda-env "${REFRESH_JUGGLEBOT_ENV_ENABLED}"
+  
 
 eval "$("${CONDA_FILEPATH}" 'shell.bash' 'hook' 2> /dev/null)"
 

--- a/environments/ubuntu-common/refresh-conda-env
+++ b/environments/ubuntu-common/refresh-conda-env
@@ -31,8 +31,14 @@ while [[ $# -gt 0 ]]; do
       print_usage
       exit 0
       ;;
-    -p|--refresh-host-provisioning)
-      REFRESH_HOST_PROVISIONING=yes
+    --refresh-host-provisioning-conda-env)
+      REFRESH_HOST_PROVISIONING_ENV_ENABLED="$2" # yes|no
+      shift
+      shift
+      ;;
+    --refresh-jugglebot-conda-env)
+      REFRESH_JUGGLEBOT_ENV_ENABLED="$2" # yes|no
+      shift
       shift
       ;;
     -*|--*)
@@ -48,7 +54,8 @@ done
 
 task 'Initialize variables'
 
-REFRESH_HOST_PROVISIONING="${REFRESH_HOST_PROVISIONING:-no}"
+REFRESH_HOST_PROVISIONING_ENV_ENABLED="${REFRESH_HOST_PROVISIONING_ENV_ENABLED:-yes}"
+REFRESH_JUGGLEBOT_ENV_ENABLED="${REFRESH_JUGGLEBOT_ENV_ENABLED:-yes}"
 CONDA_FILEPATH="${HOME}/miniforge3/bin/conda"
 REPO_DIR="${REPO_DIR:-${HOME}/Jugglebot}"
 HOST_PROVISIONING_CONDA_ENV_FILEPATH="${HOST_PROVISIONING_CONDA_ENV_FILEPATH:-${REPO_DIR}/environments/ubuntu-common/host_provisioning_conda_env.yml}"
@@ -63,7 +70,7 @@ task 'Check whether the host-provisioning Conda environment exists'
 
 if conda info --envs | grep -q '^host-provisioning\s'; then
 
-  if [[ "${REFRESH_HOST_PROVISIONING}" == 'yes' ]]; then
+  if [[ "${REFRESH_HOST_PROVISIONING_ENV_ENABLED}" == 'yes' ]]; then
 
     task 'Refresh the host-provisioning Conda environment'
 
@@ -85,8 +92,11 @@ conda activate host-provisioning
 
 task 'Run the refresh jugglebot Conda environment playbook'
 
-ANSIBLE_LOCALHOST_WARNING=False ANSIBLE_INVENTORY_UNPARSED_WARNING=False ansible-playbook \
-  "${REFRESH_PLAYBOOK_FILEPATH}" || rc="$?"
+ANSIBLE_LOCALHOST_WARNING=False \
+  ANSIBLE_INVENTORY_UNPARSED_WARNING=False \
+  ansible-playbook "${REFRESH_PLAYBOOK_FILEPATH}" \
+    -e "refresh_jugglebot_conda_env_enabled='${REFRESH_JUGGLEBOT_ENV_ENABLED}'" \
+  || rc="$?"
 
 # failed_when: the return code is nonzero
 

--- a/environments/ubuntu-common/refresh_conda_env_playbook.yml
+++ b/environments/ubuntu-common/refresh_conda_env_playbook.yml
@@ -123,7 +123,7 @@
   - name: Refresh the jugglebot Conda environment .. please be patient
     shell:
       cmd: "conda env update -n jugglebot -f '{{ repo_dir }}/ros_ws/conda_env.yml' --prune"
-    when: jugglebot_env_exists
+    when: jugglebot_env_exists and refresh_jugglebot_conda_env_enabled is truthy(convert_bool=True)
 
   - name: Install ~/.jugglebot/conda_env.sh
     import_tasks: "{{ environments_dir }}/ansible-common/copy_or_diff.yml"

--- a/environments/ubuntu-common/zshrc
+++ b/environments/ubuntu-common/zshrc
@@ -158,16 +158,26 @@ source $ZSH/oh-my-zsh.sh
 alias paliases='"${EDITOR:-vim}" "${ZSH_CUSTOM}/aliases.zsh" && source "${ZSH_CUSTOM}/aliases.zsh"'
 
 
-# TASK [Enable keychain]
-#
-# Note 1: Keychain remembers ssh-agent keys across logins during a host
-# uptime session.
-# 
-# Note 2: Keychain does not work inside a docker container because it cannot
-# inherit the identities within an auth socket.
 
-if [[ ! -f /.dockerenv ]]; then
-  eval "$(keychain --eval --quiet --agents ssh)"
+if [[ -f /.dockerenv ]]; then
+
+  # TASK [Export DBUS_SESSION_BUS_ADDRESS in the Docker container]
+  #
+  # Note: Docker doesn't have a session manager, so we run this upon creating
+  # a terminal session.
+
+  eval "$( dbus-launch --sh-syntax )"
+else
+
+  # TASK [Enable keychain]
+  #
+  # Note 1: Keychain remembers ssh-agent keys across logins during a host
+  # uptime session.
+  #
+  # Note 2: Keychain should not be necessary inside a docker container because
+  # we forward the auth socket upon connecting via `docker exec` or ssh.
+
+  eval "$( keychain --eval --quiet --agents ssh )"
 fi
 
 # TASK [Reclaim Ctrl+s and Ctrl+q from the terminal]

--- a/environments/ubuntu-wsl2/denv
+++ b/environments/ubuntu-wsl2/denv
@@ -140,7 +140,7 @@ do_exec() {
 
   if [[ "${identity_count}" -eq 0 ]]; then
     if [[ -f "${DEFAULT_SSH_KEY_CONFIG_FILEPATH}" ]]; then
-      local default_ssh_key_filepath="$(< "${DEFAULT_SSH_KEY_CONFIG_FILEPATH}")"
+      local default_ssh_key_filepath="$( < "${DEFAULT_SSH_KEY_CONFIG_FILEPATH}" )"
       if [[ -f "${default_ssh_key_filepath}" ]]; then
         ssh-add "${default_ssh_key_filepath}"
       else

--- a/environments/ubuntu-wsl2/setup.sh
+++ b/environments/ubuntu-wsl2/setup.sh
@@ -29,7 +29,22 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
-    -r|--debug-repo-dir)
+    --refresh-host-provisioning-conda-env)
+      REFRESH_HOST_PROVISIONING_ENV_ENABLED="$2" # yes|no
+      shift
+      shift
+      ;;
+    --refresh-jugglebot-conda-env)
+      REFRESH_JUGGLEBOT_ENV_ENABLED="$2" # yes|no
+      shift
+      shift
+      ;;
+    --clone-repo)
+      CLONE_REPO_ENABLED="$2" # yes|no
+      shift
+      shift
+      ;;
+    --debug-repo-dir)
       REPO_DIR="$2"
       shift
       shift
@@ -102,6 +117,7 @@ ANSIBLE_LOCALHOST_WARNING=False ANSIBLE_INVENTORY_UNPARSED_WARNING=False ansible
   -e "ssh_keypair_name='${SSH_KEYPAIR_NAME}'" \
   -e "git_name='${GIT_NAME}'" \
   -e "git_email='${GIT_EMAIL}'" \
+  -e "clone_repo_enabled='${CLONE_REPO_ENABLED}'" \
   -e "DISPLAY='${DISPLAY}'" || rc="$?"
 
 # failed_when: the return code is nonzero

--- a/environments/ubuntu_20.04-docker-native/Dockerfile
+++ b/environments/ubuntu_20.04-docker-native/Dockerfile
@@ -95,21 +95,6 @@ RUN export debian_frontend=noninteractive \
     # Clean up
     && apt-get autoremove -y
 
-# TASK [Install the same packages as in dev_env_tasks.yml to benefit from caching]
-#
-# Note: We include recommended packages because gnome-terminal and terminator
-# behave more nicely with those packages.
-
-RUN export debian_frontend=noninteractive \
-    && apt-get install -yq \
-      git \
-      gnome-terminal \
-      jq \
-      keychain \
-      terminator \
-      tmux \
-      zsh
-
 # TASK [Ensure that at least the en_US.UTF-8 UTF-8 locale is available]
 
 RUN if ! grep -o -E '^\s*en_US.UTF-8\s+UTF-8' /etc/locale.gen > /dev/null; then \
@@ -127,7 +112,7 @@ EXPOSE 22
 # TASK [Install the VSCode Server]
 
 RUN export DEBIAN_FRONTEND=noninteractive \
-    && mkdir /etc/apt/keyrings \
+    && install -m 0755 -d /etc/apt/keyrings \
     && wget -qO- https://packages.microsoft.com/keys/microsoft.asc \
       | gpg --dearmor > /etc/apt/keyrings/packages.microsoft.gpg \
     && echo "deb [arch=amd64,arm64,armhf \
@@ -139,7 +124,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 # TASK [Install ROS2 Desktop and its many dependencies]
 #
-# Note: We install this here rather than in the playbook to benefit from of
+# Note: We install this here rather than in the playbook to benefit from
 # dockerfile caching.
 
 RUN export DEBIAN_FRONTEND=noninteractive \
@@ -156,6 +141,37 @@ RUN export DEBIAN_FRONTEND=noninteractive \
       ros-foxy-desktop \
       ros-foxy-webots-ros2 \
     && /usr/bin/rosdep init
+
+# TASK [Install the Docker CLI]
+#
+# Note: We install this here rather than in the playbook to benefit from
+# dockerfile caching.
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+      -o /etc/apt/keyrings/docker.asc \
+    && chmod a+r /etc/apt/keyrings/docker.asc \
+    && echo "deb [arch=$(dpkg --print-architecture) \
+      signed-by=/etc/apt/keyrings/docker.asc] \
+      https://download.docker.com/linux/ubuntu $(lsb_release -c -s) stable" \
+      | tee /etc/apt/sources.list.d/docker.list > /dev/null \
+    && apt-get update \
+    && apt-get install -yq docker-ce-cli
+
+# TASK [Install the same packages as in dev_env_tasks.yml to benefit from caching]
+#
+# Note: We include recommended packages because gnome-terminal and terminator
+# behave more nicely with those packages.
+
+RUN export debian_frontend=noninteractive \
+    && apt-get install -yq \
+      git \
+      gnome-terminal \
+      jq \
+      keychain \
+      terminator \
+      tmux \
+      zsh
 
 # TASK [Specify /home and /tmp as volumes]
 
@@ -233,7 +249,8 @@ ARG REPO_CACHE_ID='0'
 
 RUN --mount=type=ssh,mode=0666 ssh-keyscan -t rsa github.com > \
       /home/$USERNAME/.ssh/known_hosts \
-    && git clone "${JUGGLEBOT_REPO_SSH_URL}" "/home/${USERNAME}/Jugglebot"
+    && git clone "${JUGGLEBOT_REPO_SSH_URL}" "/home/${USERNAME}/Jugglebot" \
+    && rm -f "/entrypoint/${USERNAME}/.user-dir-initialized"
 
 # TASK [Initialize the repo branch variable]
 

--- a/environments/ubuntu_20.04-docker-native/Dockerfile
+++ b/environments/ubuntu_20.04-docker-native/Dockerfile
@@ -286,7 +286,7 @@ COPY entrypoint.sh /entrypoint/
 
 # TASK [Move the default user home directory into the /entrypoint directory]
 
-RUN mv "/home/${USERNAME}" "/entrypoint/${USERNAME}"
+RUN mv -v "/home/${USERNAME}" "/entrypoint/${USERNAME}"
 
 # TASK [Specify additional environment variables for interactive sessions]
 

--- a/environments/ubuntu_20.04-docker-native/Dockerfile
+++ b/environments/ubuntu_20.04-docker-native/Dockerfile
@@ -237,8 +237,7 @@ RUN install -d .jugglebot/host_setup \
       && conda env create -f jugglebot_conda_env.yml' \
     && date +%s > .jugglebot/host_setup/conda_base_updated_timestamp \
     && rm host_provisioning_conda_env.yml \
-    && rm jugglebot_conda_env.yml \
-    && rm -f "/entrypoint/${USERNAME}/.user-dir-initialized"
+    && rm jugglebot_conda_env.yml
 
 # TASK [Initialize the repo clone variables]
 
@@ -249,8 +248,7 @@ ARG REPO_CACHE_ID='0'
 
 RUN --mount=type=ssh,mode=0666 ssh-keyscan -t rsa github.com > \
       /home/$USERNAME/.ssh/known_hosts \
-    && git clone "${JUGGLEBOT_REPO_SSH_URL}" "/home/${USERNAME}/Jugglebot" \
-    && rm -f "/entrypoint/${USERNAME}/.user-dir-initialized"
+    && git clone "${JUGGLEBOT_REPO_SSH_URL}" "/home/${USERNAME}/Jugglebot"
 
 # TASK [Initialize the repo branch variable]
 
@@ -277,8 +275,7 @@ RUN "${ENVIRONMENTS_DIR}/ubuntu_20.04-docker-native/base_setup_and_playbook.sh" 
       --environments-dir "${ENVIRONMENTS_DIR}" \
       --jugglebot-conda-env-filepath "${ENVIRONMENTS_DIR}/ubuntu-common/jugglebot_conda_env.yml" \
       --ros-workspace-dir "${ROS_WORKSPACE_DIR}" \
-      --ansible-become-pass "${USERNAME}" \
-    && rm -f "/entrypoint/${USERNAME}/.user-dir-initialized"
+      --ansible-become-pass "${USERNAME}"
 
 # TASK [Install entrypoint.sh]
 

--- a/environments/ubuntu_20.04-docker-native/entrypoint.sh
+++ b/environments/ubuntu_20.04-docker-native/entrypoint.sh
@@ -11,10 +11,6 @@ INIT_FLAG_FILEPATH="${HOME}/.user-dir-initialized"
 
 sudo /usr/bin/dbus-daemon --system &
 
-# TASK [Set the dbus environment variables]
-
-eval "$(dbus-launch --sh-syntax)"
-
 # TASK [Start sshd]
 
 sudo /usr/sbin/sshd -D &

--- a/environments/ubuntu_20.04-docker-native/entrypoint.sh
+++ b/environments/ubuntu_20.04-docker-native/entrypoint.sh
@@ -11,6 +11,10 @@ INIT_FLAG_FILEPATH="${HOME}/.user-dir-initialized"
 
 sudo /usr/bin/dbus-daemon --system &
 
+# TASK [Set the dbus environment variables]
+
+eval "$(dbus-launch --sh-syntax)"
+
 # TASK [Start sshd]
 
 sudo /usr/sbin/sshd -D &

--- a/environments/ubuntu_20.04-docker-native/main_playbook.yml
+++ b/environments/ubuntu_20.04-docker-native/main_playbook.yml
@@ -28,12 +28,6 @@
     vars:
       environments_dir: "{{ playbook_dir }}/.."
 
-  - name: Install the Docker CLI package
-    package:
-      name: docker-ce-cli
-      state: present
-    become: yes
-
   - name: Update the rosdep package manager
     command:
       cmd: /usr/bin/rosdep update


### PR DESCRIPTION
Running gnome-terminal had been broken because it depends on an environment variable provided by dbus-launch. That variable is usually exported by a desktop manager or some other user session manager. Since the container doesn't have one of those, we need to export the variable at the start of the terminal session.

Along the way, we added some flags on the provisioning scripts to enable shortcuts. These mostly bypass slow tasks if those tasks aren't instrumental to the testing of provisioning that's occurring.

In the same vein of speeding up repeated builds, we reorganized the Dockerfile and moved the Docker CLI installation out of the playbook and into the Dockerfile to benefit from caching.

Previously, we had a broken implementation for refreshing the home directory. The setup script now has an option to retain the home directory. Its default is not to retain.