### PR TITLE
Fix sklearn regression

### DIFF
--- a/environments/ubuntu-common/refresh_dependencies_playbook.yml
+++ b/environments/ubuntu-common/refresh_dependencies_playbook.yml
@@ -199,4 +199,3 @@
       chdir: "{{ repo_dir }}/ros_ws"
     when: "'/etc/ros/rosdep/sources.list.d/20-default.list' is file"
 
-

--- a/environments/ubuntu-common/refresh_dependencies_playbook.yml
+++ b/environments/ubuntu-common/refresh_dependencies_playbook.yml
@@ -43,7 +43,7 @@
     # Note: We don't use Bash for development, but we still want that shell to
     # be usable for exploration by a potential contributor who may not be
     # familiar with Z Shell.
-    shell: 
+    shell:
       cmd: conda init bash
 
   - name: Set the conda_base_update_needed variable
@@ -89,7 +89,7 @@
     register: conda_info_grep_result
     failed_when: conda_info_grep_result.rc not in [0, 1]
     changed_when: False
-  
+
   - name: Set the jugglebot_env_exists variable
     set_fact:
       jugglebot_env_exists: "{{ conda_info_grep_result.rc == 0 }}"
@@ -98,7 +98,7 @@
     command:
       cmd: "conda env create -f '{{ host_setup_defaults_dir }}/conda_env.yml'"
     when: not jugglebot_env_exists
-  
+
   - name: Create a file for the jugglebot Conda environment backup
     tempfile:
       path: "{{ host_setup_backups_dir }}"
@@ -184,4 +184,19 @@
         && {{ home_dir }}/.local/share/fnm/fnm use \
         --install-if-missing {{ node_version }}
       executable: /usr/bin/bash
+
+  - name: Update the rosdep package manager
+    command:
+      cmd: /usr/bin/rosdep update
+    when: "'/etc/ros/rosdep/sources.list.d/20-default.list' is file"
+
+  - name: Install the Jugglebot ROS dependencies
+    shell:
+      cmd: >
+        source /opt/ros/{{ ros_version_codename }}/setup.bash
+        && rosdep install -i --from-path src --rosdistro {{ ros_codename }}
+      executable: /usr/bin/bash
+      chdir: "{{ repo_dir }}/ros_ws"
+    when: "'/etc/ros/rosdep/sources.list.d/20-default.list' is file"
+
 

--- a/environments/ubuntu-common/refresh_dependencies_playbook.yml
+++ b/environments/ubuntu-common/refresh_dependencies_playbook.yml
@@ -193,8 +193,8 @@
   - name: Install the Jugglebot ROS dependencies
     shell:
       cmd: >
-        source /opt/ros/{{ ros_version_codename }}/setup.bash
-        && rosdep install -i --from-path src --rosdistro {{ ros_codename }}
+        source /opt/ros/{{ ros_codename }}/setup.bash
+        && rosdep install -y -i --from-path src --rosdistro {{ ros_codename }}
       executable: /usr/bin/bash
       chdir: "{{ repo_dir }}/ros_ws"
     when: "'/etc/ros/rosdep/sources.list.d/20-default.list' is file"

--- a/environments/ubuntu-docker/setup.sh
+++ b/environments/ubuntu-docker/setup.sh
@@ -172,7 +172,7 @@ JUGGLEBOT_CONFIG_DIR="${JUGGLEBOT_CONFIG_DIR:-${HOME}/.jugglebot}"
 
 task 'Enable ssh-agent if necessary'
 
-if ! pgrep ssh-agent >/dev/null 2>&1; then
+if [[ -z "${SSH_AUTH_SOCK:-}" ]]; then
   eval "$(ssh-agent -s)"
 fi
 

--- a/environments/ubuntu-docker/setup.sh
+++ b/environments/ubuntu-docker/setup.sh
@@ -170,9 +170,11 @@ SSH_PUBLIC_KEY_FILEPATH="${SSH_IDENTITY_FILEPATH}.pub"
 BUILD_CONTEXT_DIR="${JUGGLEBOT_REPO_DIR}/environments/ubuntu-docker"
 JUGGLEBOT_CONFIG_DIR="${JUGGLEBOT_CONFIG_DIR:-${HOME}/.jugglebot}"
 
-task 'Enable ssh-agent'
+task 'Enable ssh-agent if necessary'
 
-eval "$(ssh-agent -s)"
+if ! pgrep ssh-agent >/dev/null 2>&1; then
+  eval "$(ssh-agent -s)"
+fi
 
 task 'Assert that the configured ssh keypair exists'
 

--- a/environments/ubuntu-wsl2/main_playbook.yml
+++ b/environments/ubuntu-wsl2/main_playbook.yml
@@ -266,20 +266,28 @@
     become: yes
 
   - name: Initialize the rosdep package manager
+    # Note: We skip this during upgrade mode because it will have been
+    # performed by ubuntu-common/refresh-dependencies.
     command:
       cmd: /usr/bin/rosdep init
-    when: not '/etc/ros/rosdep/sources.list.d/20-default.list' is file
+    when: not '/etc/ros/rosdep/sources.list.d/20-default.list' is file and not upgrade_mode_enabled
     become: yes
 
   - name: Update the rosdep package manager
+    # Note: We skip this during upgrade mode because it will have been
+    # performed by ubuntu-common/refresh-dependencies.
     command:
       cmd: /usr/bin/rosdep update
+    when: not upgrade_mode_enabled
 
   - name: Install the Jugglebot ROS dependencies
+    # Note: We skip this during upgrade mode because it will have been
+    # performed by ubuntu-common/refresh-dependencies.
     shell:
       cmd: >
         source /opt/ros/{{ ros_version_codename }}/setup.bash
         && rosdep install -i --from-path src --rosdistro {{ ros_version_codename }}
       executable: /usr/bin/bash
       chdir: "{{ jugglebot_repo_dir }}/ros_ws"
+    when: not upgrade_mode_enabled
 

--- a/environments/ubuntu-wsl2/setup.sh
+++ b/environments/ubuntu-wsl2/setup.sh
@@ -197,7 +197,7 @@ fi
 
 task 'Enable ssh-agent if necessary'
 
-if ! pgrep ssh-agent >/dev/null 2>&1; then
+if [[ -z "${SSH_AUTH_SOCK:-}" ]]; then
   eval "$(ssh-agent -s)"
 fi
 

--- a/environments/ubuntu-wsl2/setup.sh
+++ b/environments/ubuntu-wsl2/setup.sh
@@ -195,9 +195,11 @@ editor, install it before running this script." >&2
   fi
 fi
 
-task 'Enable ssh-agent'
+task 'Enable ssh-agent if necessary'
 
-eval "$(ssh-agent -s)"
+if ! pgrep ssh-agent >/dev/null 2>&1; then
+  eval "$(ssh-agent -s)"
+fi
 
 task 'Assert that the configured ssh keypair exists'
 

--- a/environments/ubuntu-wsl2/setup.sh
+++ b/environments/ubuntu-wsl2/setup.sh
@@ -27,6 +27,15 @@ Options:
   -N|--git-name [your full name]
                          Specify your name for the user.name section of
                          ~/.gitconfig
+  --x-clone-repo [yes|no]
+                         Enable/disable ensuring that Jugglebot repo is cloned
+                         and clean (default: yes)
+  --x-refresh-host-provisioning-conda-env [yes|no]
+                         Enable/disable refreshing the host-provisining Conda
+                         environment (default: yes)
+  --x-refresh-jugglebot-conda-env)
+                         Enable/disable refreshing the jugglebot Conda
+                         environment (default: yes)
 
 '
 }

--- a/environments/ubuntu-wsl2/setup.sh
+++ b/environments/ubuntu-wsl2/setup.sh
@@ -199,11 +199,23 @@ task 'Enable ssh-agent'
 
 eval "$(ssh-agent -s)"
 
-task 'Add the ssh private key'
+task 'Assert that the configured ssh keypair exists'
 
-# Note: This will prompt for the passphrase if the key requires one
+if [[ ! -f "${SSH_IDENTITY_FILEPATH}" || ! -f "${SSH_IDENTITY_FILEPATH}.pub" ]]; then
+  echo '[Error]: The specified ssh keypair does not exist.' >&2
+  exit $EX_UNAVAILABLE
+fi
 
-ssh-add "${SSH_IDENTITY_FILEPATH}"
+task 'Check whether the ssh-agent contains the configured identity'
+
+if ! ssh-add -T "${SSH_IDENTITY_FILEPATH}.pub" >/dev/null 2>&1; then
+
+  task 'Add the configured identity to the ssh-agent'
+
+  # Note: This will prompt for a passphrase if the key requires one.
+
+  ssh-add "${SSH_IDENTITY_FILEPATH}"
+fi
 
 task 'Source ubuntu-common/base_setup.sh'
 

--- a/ros_ws/conda_env.yml.j2
+++ b/ros_ws/conda_env.yml.j2
@@ -1,6 +1,6 @@
 ---
 # TASK [Educate about how to apply changes]
-# 
+#
 # After editing this file, you can apply changes by running the following
 # utility:
 #
@@ -23,10 +23,16 @@
 # However, it will not overwrite those `~/.jugglebot` config files if you have
 # manually made changes to the installed versions.
 #
-# Finally, it will ensure that fnm has installed the Node.js version that is
+# It will then ensure that fnm has installed the Node.js version that is
 # specifed in the following file:
 #
 #   $JUGGLEBOT_REPO_DIR/ros_ws/gui/.node_version
+#
+# Lastly, it will ensure that rosdep has installed the jugglebot ROS project
+# dependencies that are specified in the following file:
+#
+#   $JUGGLEBOT_REPO_DIR/ros_ws/src/jugglebot/package.xml
+#
 
 
 name: jugglebot
@@ -37,14 +43,14 @@ dependencies:
   - pip
 
   # TASK [Specify the Jugglebot project requirements]
-  
+
   - cantools
   - matplotlib
   - numpy
   - python-can
-  
+
   # TASK [Specify the Yasmin requirements]
-  
+
   - expiringdict
   - flask
   - waitress
@@ -58,21 +64,22 @@ dependencies:
     # required_by: $JUGGLEBOT_REPO_DIR/environments/ubuntu-docker/setup.sh
 
   # TASK [Specify the pip requirements]
-  # 
+  #
   # Note: We prefer to specify the Conda package unless (a) no Conda package
   # exists or (b) the Conda package would install a binary that we prefer to
   # manage via an apt repository package.
 
   - pip:
-    
+
     # TASK [Specify the Jugglebot project pip requirements]
-    
+
     - numpy-quaternion==2022.4.4
     - pyspacemouse==1.0.9
+    - qtm-rt
 
     # TASK [Specify the shell environment pip requirements]
     #
     # Note: We choose the pip package for tmuxp because we prefer to use the
     # tmux binary that is provided by the Ubuntu apt repository.
-    
+
     - tmuxp

--- a/ros_ws/src/jugglebot/package.xml
+++ b/ros_ws/src/jugglebot/package.xml
@@ -20,8 +20,7 @@
 
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>yasmin_ros</exec_depend>
-  <exec_depend>qtm_rt</exec_depend>
-  <exec_depend>sklearn</exec_depend>
+  <exec_depend>python-sklearn</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ros_ws/src/jugglebot/package.xml
+++ b/ros_ws/src/jugglebot/package.xml
@@ -20,7 +20,7 @@
 
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>yasmin_ros</exec_depend>
-  <exec_depend>python-sklearn</exec_depend>
+  <exec_depend>python3-sklearn</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
This fixes a regression in the rosdep dependencies that occurred upon rebasing on the upstream branch. This will probably introduce a merge conflict next time we rebase. But that's necessary to make the preview usable now.

Along the way, we decreased the number of ssh agents and documented some debug options.